### PR TITLE
Update(bug): Fix crash in splash screen

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -1,8 +1,9 @@
 # 强制以管理员权限以运行
-If (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-    $arguments = "& '" + $myinvocation.mycommand.definition + "'"
-    Start-Process powershell -Verb runAs -ArgumentList $arguments
-    Break
+$currentUser = New-Object Security.Principal.WindowsPrincipal $([Security.Principal.WindowsIdentity]::GetCurrent())
+$testadmin = $currentUser.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+if ($testadmin -eq $false) {
+    Start-Process powershell.exe -Verb RunAs -ArgumentList ('-noprofile -noexit -file "{0}" -elevated' -f ($myinvocation.MyCommand.Definition))
+    exit $LASTEXITCODE
 }
 
 $script:LICENCE = @"


### PR DESCRIPTION
修复了一个引起闪退的 bug
用 `-noexit` 阻塞管理员权限运行的 PowerShell，防止其退出